### PR TITLE
新增篮球队和戏剧社活动，并在报名时检查学生是否已注册

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,20 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
 # In-memory activity database
+# 新增两项活动：一项体育活动（Basketball Team），一项文艺活动（Drama Club）
 activities = {
+    "Basketball Team": {
+        "description": "Join the school basketball team and participate in matches and training sessions",
+        "schedule": "Wednesdays and Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 15,
+        "participants": []
+    },
+    "Drama Club": {
+        "description": "Explore acting, stage production, and perform in school plays",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -61,7 +74,9 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
-
+    # Check if already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Already signed up")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
This pull request adds two new activities to the in-memory activity database and improves the signup logic to prevent duplicate registrations. The main changes are grouped below:

Activity management improvements:

* Added two new activities, "Basketball Team" (sports) and "Drama Club" (arts), each with their own description, schedule, participant limit, and an empty participant list.

Signup logic enhancement:

* Updated the `signup_for_activity` function to check if a user has already signed up for an activity and raise an HTTP 400 error if so, preventing duplicate registrations.